### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 license = "MIT"
 description = "Entity Component Message architecture a la Caves of Qud"
-repository = "https://www.github.com/gamma-delta/palkia"
+repository = "https://github.com/gamma-delta/palkia"
 keywords = ["gamedev"]
 categories = ["game-development"]
 


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96